### PR TITLE
Clean up resource revamp

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,10 +4,5 @@ default['gcp']['service_account_json'] = '/etc/caddy/gcp_service_account.json'
 default['gcp']['service_account_vault'] = 'gcp_service_account_json'
 default['gcp']['project'] = ''
 
-default['chef-vault']['databag_fallback'] = true
-
 default['caddy']['user'] = 'caddy'
 default['caddy']['group'] = 'caddy'
-default['caddy']['wildcard_domain'] = '*.lab.acep.uaf.edu'
-default['caddy']['acme_email'] = 'uaf-acep-ci@alaska.edu'
-default['caddy']['sites_data_bag'] = ''

--- a/docs/caddy_handler.md
+++ b/docs/caddy_handler.md
@@ -1,7 +1,6 @@
-## caddy_site
+## caddy_handler
 
-Site configuration accumulator, 
-
+Site handler configuration accumulator, 
 
 ## Properties
 

--- a/docs/caddy_service.md
+++ b/docs/caddy_service.md
@@ -16,3 +16,13 @@ Manages global configuration for caddy service
 |acme_ca_root|string|
 
 ## Examples
+
+```ruby
+caddy_service 'caddy' do
+  acme_staging true
+  acme_staging_url 'https://localhost:14000/dir'
+  acme_ca_root '/etc/ssl/certs/pebble.minica.pem'
+  acme_email 'test@test.com'
+  action [:install, :enable, :start]
+end
+```

--- a/docs/caddy_service.md
+++ b/docs/caddy_service.md
@@ -1,5 +1,18 @@
 ## caddy_service
 
+Manages global configuration for caddy service
+
 ## Properties
+
+|Name   |Type       |Default             |Description                        |
+|-------|-----------|--------------------|-----------------------------------|
+|user|string|
+|group|string|
+|cookbook|string|
+|source|string|
+|acme_email|string|
+|acme_staging|true,false|
+|acme_staging_url|string|
+|acme_ca_root|string|
 
 ## Examples

--- a/docs/caddy_site.md
+++ b/docs/caddy_site.md
@@ -1,0 +1,17 @@
+## caddy_site
+
+Manages site level configuration
+
+## Properties
+
+|Name            |Type       |Default   |Description                                          |
+|----------------|-----------|----------|-----------------------------------------------------|
+|dns_verification|string     |          |Set the snippet name to use for dns verification for the site|
+|content         |Array      |          |Array of configuration lines to add to at the site level|
+## Examples
+
+```ruby
+caddy_site '*.camio.acep.uaf.edu' do 
+  dns_verification 'tls-dns'
+end
+```

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,3 +21,6 @@ platforms:
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -21,8 +21,8 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-20.04
-  - name: centos-8
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default
@@ -31,5 +31,7 @@ suites:
         project: clound-dns-321021
       caddy:
         sites_data_bag: test_sites
+      chef-vault:
+        databag_fallback: true
     provisioner:
       policyfile: ./policies/default.rb

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -36,6 +36,8 @@ module AcepCaddy
     def site(resource)
       content = []
 
+      name = resource.name.gsub('.', '_')
+
       content << encode_gzip(resource.gzip)
       unless resource.content.nil?
         content << resource.content
@@ -52,8 +54,8 @@ module AcepCaddy
       end
 
       <<-EOF
-#{site_match(resource.name, resource)}
-handle @#{resource.name} {
+#{site_match(name, resource)}
+handle @#{name} {
   #{content.join("\n")}
 }
       EOF

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Will Fisher'
 maintainer_email 'will@alaska.edu'
 license 'Apache-2.0'
 description 'Installs/Configures acep-caddy'
-version '2.0.0'
+version '2.1.0'
 chef_version '>= 16.0'
 
 # The `issues_url` points to the location where issues for this cookbook are

--- a/policies/default.lock.json
+++ b/policies/default.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "daa39c27de7cfd941b1fe32b3f700dbe82e3600edaaa5c810c2f80bbd1d844ac",
+  "revision_id": "86320506dac00f0dfe728038c9e32c59e6855ef616b8f9fbbe21721e63a42a86",
   "name": "acep-caddy",
   "run_list": [
     "recipe[test::default]",
@@ -11,18 +11,18 @@
   "cookbook_locks": {
     "acep-caddy": {
       "version": "2.0.0",
-      "identifier": "7f11d7f7b132543de2c3c4d290fdedb7ec16b47c",
-      "dotted_decimal_identifier": "35766941313479252.17419304027984125.261374195709052",
+      "identifier": "efcc90a6da90696c3bf6f9bb4393e32a3098b614",
+      "dotted_decimal_identifier": "67497441080545385.30465229422543763.249770343446036",
       "source": "..",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "e8f2df95125a48739426b37f3d2d583b870ab80d",
+        "revision": "470682d71510cf15f4013cd9c2a45f97e9c7c216",
         "working_tree_clean": false,
-        "published": true,
+        "published": false,
         "synchronized_remote_branches": [
-          "origin/will/convert_to_resources"
+
         ]
       },
       "source_options": {
@@ -82,11 +82,11 @@
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "e8f2df95125a48739426b37f3d2d583b870ab80d",
+        "revision": "470682d71510cf15f4013cd9c2a45f97e9c7c216",
         "working_tree_clean": false,
-        "published": true,
+        "published": false,
         "synchronized_remote_branches": [
-          "origin/will/convert_to_resources"
+
         ]
       },
       "source_options": {

--- a/policies/default.lock.json
+++ b/policies/default.lock.json
@@ -1,8 +1,9 @@
 {
-  "revision_id": "764da0509c65260219ca249e1dd3e61e069e1610477ee2b156c335ef909ca341",
+  "revision_id": "daa39c27de7cfd941b1fe32b3f700dbe82e3600edaaa5c810c2f80bbd1d844ac",
   "name": "acep-caddy",
   "run_list": [
-    "recipe[test::default]"
+    "recipe[test::default]",
+    "recipe[acep-caddy::acep]"
   ],
   "included_policy_locks": [
 
@@ -10,14 +11,14 @@
   "cookbook_locks": {
     "acep-caddy": {
       "version": "2.0.0",
-      "identifier": "5e0d94391ed748fd0c8acf76eca33b06bc3e1220",
-      "dotted_decimal_identifier": "26473578075445064.71226959433493667.64900114027040",
+      "identifier": "7f11d7f7b132543de2c3c4d290fdedb7ec16b47c",
+      "dotted_decimal_identifier": "35766941313479252.17419304027984125.261374195709052",
       "source": "..",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "d626c63f167eb9b5b1b94fc5f6ad697a785f6d9d",
+        "revision": "e8f2df95125a48739426b37f3d2d583b870ab80d",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -74,14 +75,14 @@
     },
     "test": {
       "version": "0.1.0",
-      "identifier": "9e51d5cd2be900560dca76c33046a84f78188a97",
-      "dotted_decimal_identifier": "44563025032374528.24222011224174662.185059270757015",
+      "identifier": "9c00800396766f13f7ff5e05b0218bb5414f418a",
+      "dotted_decimal_identifier": "43910646182868591.5620700723654689.153610601054602",
       "source": "../test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "d626c63f167eb9b5b1b94fc5f6ad697a785f6d9d",
+        "revision": "e8f2df95125a48739426b37f3d2d583b870ab80d",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/policies/default.lock.json
+++ b/policies/default.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "86320506dac00f0dfe728038c9e32c59e6855ef616b8f9fbbe21721e63a42a86",
+  "revision_id": "fff54f29081b87425a96d051d5bfe98ee27d2e806c3b38325dedf7a2f0ca6650",
   "name": "acep-caddy",
   "run_list": [
     "recipe[test::default]",
@@ -10,19 +10,19 @@
   ],
   "cookbook_locks": {
     "acep-caddy": {
-      "version": "2.0.0",
-      "identifier": "efcc90a6da90696c3bf6f9bb4393e32a3098b614",
-      "dotted_decimal_identifier": "67497441080545385.30465229422543763.249770343446036",
+      "version": "2.1.0",
+      "identifier": "f63d18e48aa31b0121956ed2539d5da9e159ea86",
+      "dotted_decimal_identifier": "69310021393621787.318400669832093.102984211622534",
       "source": "..",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "470682d71510cf15f4013cd9c2a45f97e9c7c216",
+        "revision": "7b5086b720fed680890926ea30b3952a3ec2c212",
         "working_tree_clean": false,
-        "published": false,
+        "published": true,
         "synchronized_remote_branches": [
-
+          "origin/will/cleanup_resource_revamp"
         ]
       },
       "source_options": {
@@ -75,18 +75,18 @@
     },
     "test": {
       "version": "0.1.0",
-      "identifier": "9c00800396766f13f7ff5e05b0218bb5414f418a",
-      "dotted_decimal_identifier": "43910646182868591.5620700723654689.153610601054602",
+      "identifier": "40a11fa1f66455341c7b7b19e8aab7e0e4fabae1",
+      "dotted_decimal_identifier": "18191555742819413.14668015460804778.202176542194401",
       "source": "../test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "470682d71510cf15f4013cd9c2a45f97e9c7c216",
+        "revision": "7b5086b720fed680890926ea30b3952a3ec2c212",
         "working_tree_clean": false,
-        "published": false,
+        "published": true,
         "synchronized_remote_branches": [
-
+          "origin/will/cleanup_resource_revamp"
         ]
       },
       "source_options": {
@@ -130,7 +130,7 @@
       ]
     ],
     "dependencies": {
-      "acep-caddy (2.0.0)": [
+      "acep-caddy (2.1.0)": [
         [
           "golang",
           ">= 0.0.0"

--- a/policies/default.rb
+++ b/policies/default.rb
@@ -10,7 +10,7 @@ name 'acep-caddy'
 default_source :supermarket
 
 # run_list: chef-client will run these recipes in the order specified.
-run_list 'test::default'
+run_list 'test::default', 'acep-caddy::acep'
 
 # Specify a custom source for a single cookbook:
 cookbook 'acep-caddy', path: '..'

--- a/recipes/acep.rb
+++ b/recipes/acep.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook:: acep-caddy
+# Recipe:: acep
+#
+# Copyright:: 2025, The Authors, All Rights Reserved.
+
+gcp_service_account_file = '/etc/caddy/gcp_service_account.json'
+gcp_service_account_json = chef_vault_item('credentials', node['gcp']['service_account_vault'])
+
+file gcp_service_account_file do
+  content gcp_service_account_json['file-content']
+  owner node['caddy']['user']
+  group node['caddy']['group']
+  mode '0700'
+  action :create
+end
+
+caddy_snippet 'tls-dns' do
+  content <<-EOF
+  tls {
+      dns googleclouddns {
+          gcp_project #{node['gcp']['project']}
+          gcp_application_default #{gcp_service_account_file}
+      }
+  }
+  EOF
+end

--- a/resources/caddy_handler.rb
+++ b/resources/caddy_handler.rb
@@ -1,0 +1,38 @@
+# To learn more about Custom Resources, see https://docs.chef.io/custom_resources/
+unified_mode true
+
+provides :caddy_handler
+
+# related to add actions
+property :domain, String
+property :dns_verification, String, default: 'tls-dns'
+property :fqdn, String
+property :match, Array, default: []
+property :content, String
+property :reverse_proxy, Hash
+property :redirect, String
+property :gzip, [true, false], default: true
+
+action_class do
+  include AcepCaddy::CaddyHelpers
+end
+
+action :add do
+  if new_resource.fqdn.nil?
+    new_resource.fqdn = new_resource.name
+  end
+
+  if new_resource.domain.nil?
+    new_resource.domain = new_resource.fqdn
+  end
+
+  content = site(new_resource)
+
+  with_run_context :root do
+    edit_resource(:template, '/etc/caddy/Caddyfile') do |new_resource|
+      variables[:domains] ||= {}
+      variables[:domains][new_resource.domain] ||= { extras: [], sites: {} }
+      variables[:domains][new_resource.domain][:sites][new_resource.name] = content
+    end
+  end
+end

--- a/resources/caddy_handler.rb
+++ b/resources/caddy_handler.rb
@@ -31,7 +31,7 @@ action :add do
   with_run_context :root do
     edit_resource(:template, '/etc/caddy/Caddyfile') do |new_resource|
       variables[:domains] ||= {}
-      variables[:domains][new_resource.domain] ||= { extras: [], sites: {} }
+      variables[:domains][new_resource.domain] ||= { content: [], sites: {} }
       variables[:domains][new_resource.domain][:sites][new_resource.name] = content
     end
   end

--- a/resources/caddy_service.rb
+++ b/resources/caddy_service.rb
@@ -44,17 +44,6 @@ action :install do
     action :create
   end
 
-  gcp_service_account_file = '/etc/caddy/gcp_service_account.json'
-
-  file gcp_service_account_file do
-    content new_resource.gcp_service_account_json
-    owner new_resource.user
-    group new_resource.group
-    mode '0700'
-    action :create
-    notifies :reload, 'service[caddy]', :delayed
-  end
-
   with_run_context :root do
     service 'caddy' do
       supports status: true, restart: true, reload: true
@@ -86,17 +75,6 @@ action :install do
     transport http {
       tls
       tls_insecure_skip_verify
-    }
-    EOF
-  end
-
-  caddy_snippet 'tls-dns' do
-    content <<-EOF
-    tls {
-        dns googleclouddns {
-            gcp_project #{new_resource.gcp_project}
-            gcp_application_default #{gcp_service_account_file}
-        }
     }
     EOF
   end

--- a/resources/caddy_site.rb
+++ b/resources/caddy_site.rb
@@ -15,7 +15,7 @@ action :add do
     edit_resource(:template, '/etc/caddy/Caddyfile') do |new_resource|
       variables[:domains] ||= {}
       variables[:domains][new_resource.name] ||= { content: [], sites: {} }
-      variables[:domains][new_resource.name][:content] += new_resource.extras
+      variables[:domains][new_resource.name][:content] += new_resource.content
       variables[:domains][new_resource.name][:content].uniq!
     end
   end

--- a/resources/caddy_site.rb
+++ b/resources/caddy_site.rb
@@ -20,4 +20,3 @@ action :add do
     end
   end
 end
-

--- a/resources/caddy_site.rb
+++ b/resources/caddy_site.rb
@@ -1,35 +1,23 @@
 # To learn more about Custom Resources, see https://docs.chef.io/custom_resources/
 unified_mode true
 
-provides :caddy_config
 provides :caddy_site
 
 # related to add actions
-property :domain, String
-property :fqdn, String, required: true
-property :match, Array, default: []
-property :content, String
-property :reverse_proxy, Hash
-property :redirect, String
-property :gzip, [true, false], default: true
-
-action_class do
-  include AcepCaddy::CaddyHelpers
-end
+property :dns_verification, String
+property :extras, Array, default: []
 
 action :add do
-  if new_resource.domain.nil?
-    new_resource.domain = new_resource.fqdn
-  end
-
-  content = site(new_resource)
+  import_verify = "import #{new_resource.dns_verification}"
+  new_resource.extras << import_verify
 
   with_run_context :root do
     edit_resource(:template, '/etc/caddy/Caddyfile') do |new_resource|
-      variables[:dns_verify] = new_resource.domain.include? '*'
       variables[:domains] ||= {}
-      variables[:domains][new_resource.domain] ||= {}
-      variables[:domains][new_resource.domain][new_resource.name] = content
+      variables[:domains][new_resource.name] ||= { extras: [], sites: {} }
+      variables[:domains][new_resource.name][:extras] += new_resource.extras
+      variables[:domains][new_resource.name][:extras].uniq!
     end
   end
 end
+

--- a/resources/caddy_site.rb
+++ b/resources/caddy_site.rb
@@ -5,18 +5,18 @@ provides :caddy_site
 
 # related to add actions
 property :dns_verification, String
-property :extras, Array, default: []
+property :content, Array, default: []
 
 action :add do
   import_verify = "import #{new_resource.dns_verification}"
-  new_resource.extras << import_verify
+  new_resource.content << import_verify
 
   with_run_context :root do
     edit_resource(:template, '/etc/caddy/Caddyfile') do |new_resource|
       variables[:domains] ||= {}
-      variables[:domains][new_resource.name] ||= { extras: [], sites: {} }
-      variables[:domains][new_resource.name][:extras] += new_resource.extras
-      variables[:domains][new_resource.name][:extras].uniq!
+      variables[:domains][new_resource.name] ||= { content: [], sites: {} }
+      variables[:domains][new_resource.name][:content] += new_resource.extras
+      variables[:domains][new_resource.name][:content].uniq!
     end
   end
 end

--- a/spec/unit/recipes/acep_spec.rb
+++ b/spec/unit/recipes/acep_spec.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook:: acep-caddy
+# Spec:: acep
+#
+# Copyright:: 2025, The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'acep-caddy::acep' do
+  context 'When all attributes are default, on Ubuntu 20.04' do
+    # for a complete list of available platforms and versions see:
+    # https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md
+    platform 'ubuntu', '20.04'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'When all attributes are default, on CentOS 8' do
+    # for a complete list of available platforms and versions see:
+    # https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md
+    platform 'centos', '8'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/templates/Caddyfile_resource.erb
+++ b/templates/Caddyfile_resource.erb
@@ -17,12 +17,10 @@
 }
 <%- end %>
 
-<%- @domains.each do |domain,sites| %>
+<%- @domains.each do |domain,config| %>
 <%= domain %> {
-    <%- if @dns_verfication %>
-        import tls-dns
-    <%- end %>
-    <%- sites.each do |fqdn,content| %>
+    <%= config[:extras].join("\n") %>
+    <%- config[:sites].each do |fqdn,content| %>
     <%= content %>
     <%- end %>
 }

--- a/templates/Caddyfile_resource.erb
+++ b/templates/Caddyfile_resource.erb
@@ -19,7 +19,7 @@
 
 <%- @domains.each do |domain,config| %>
 <%= domain %> {
-    <%= config[:extras].join("\n") %>
+    <%= config[:content].join("\n") %>
     <%- config[:sites].each do |fqdn,content| %>
     <%= content %>
     <%- end %>

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -48,7 +48,7 @@ caddy_handler 'psi.lab.acep.uaf.edu' do
   action :add
 end
 
-caddy_site '*.camio.acep.uaf.edu' do 
+caddy_site '*.camio.acep.uaf.edu' do
   dns_verification 'tls-dns'
 end
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -13,19 +13,15 @@ file '/etc/ssl/certs/pebble.minica.pem' do
   mode '0644'
 end
 
-gcp_json = chef_vault_item('credentials', node['gcp']['service_account_vault'])
 caddy_service 'caddy' do
   acme_staging true
   acme_staging_url 'https://localhost:14000/dir'
   acme_ca_root '/etc/ssl/certs/pebble.minica.pem'
-  acme_email node['caddy']['acme_email']
-  gcp_project node['gcp']['project']
-  gcp_service_account_json gcp_json['file-content']
-
+  acme_email 'test@test.com'
   action [:install, :enable, :start]
 end
 
-caddy_site 'hello_test' do
+caddy_handler 'hello_test' do
   fqdn 'hello.lab.acep.uaf.edu'
   match ['path /test']
   content <<-EOF
@@ -34,7 +30,7 @@ respond "Hello test!"
   action :add
 end
 
-caddy_site 'hello' do
+caddy_handler 'hello' do
   fqdn 'hello.lab.acep.uaf.edu'
   content <<-EOF
 respond "Hello World!"
@@ -42,19 +38,21 @@ respond "Hello World!"
   action :add
 end
 
-caddy_site 'test' do
-  fqdn 'test.lab.acep.uaf.edu'
-  reverse_proxy to: 'localhost:8080', skip_verify: true
+caddy_handler 'test.lab.acep.uaf.edu' do
+  reverse_proxy to: 'localhost:9443', with: ['https-insecure']
   action :add
 end
 
-caddy_site 'psi' do
-  fqdn 'psi.lab.acep.uaf.edu'
+caddy_handler 'psi.lab.acep.uaf.edu' do
   redirect 'https://www.uaf.edu/acep/research/power-systems-integration.php'
   action :add
 end
 
-caddy_site 'foo' do
+caddy_site '*.camio.acep.uaf.edu' do 
+  dns_verification 'tls-dns'
+end
+
+caddy_handler 'foo' do
   domain '*.camio.acep.uaf.edu'
   fqdn 'foo.camio.acep.uaf.edu'
   content <<-EOF

--- a/test/integration/default/acep_test.rb
+++ b/test/integration/default/acep_test.rb
@@ -1,0 +1,16 @@
+# Chef InSpec test for recipe acep-caddy::acep
+
+# The Chef InSpec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec/resources/
+
+unless os.windows?
+  # This is an example test, replace with your own test.
+  describe user('root'), :skip do
+    it { should exist }
+  end
+end
+
+# This is an example test, replace it with your own test.
+describe port(80), :skip do
+  it { should_not be_listening }
+end


### PR DESCRIPTION
Cleaning up some implementation of resources to remove acep specific config handling.

Instead it's now a recipe that should be an example to implement in the server cookbook. Also clean up resource names to better match the internal names for Caddy configs:w
